### PR TITLE
[B] Fix index page randomness

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -431,10 +431,11 @@ function buildUniqueIntArray(length) {
   return randomInts;
 }
 
-export default function Home() {
-  const headline = getRandomHeadline();
-  const name = getRandomTechBusinessName();
-  const svgComponentsIndexArray = buildUniqueIntArray(3);
+export default function Home({
+  headline,
+  name,
+  svgComponentsIndexArray
+}) {
 
   return (
     <>
@@ -468,3 +469,17 @@ export default function Home() {
     </>
   );
 }
+
+export const getServerSideProps = () => {
+  const headline = getRandomHeadline();
+  const name = getRandomTechBusinessName();
+  const svgComponentsIndexArray = buildUniqueIntArray(3);
+
+  return {
+    props: {
+      headline,
+      name,
+      svgComponentsIndexArray,
+    },
+  };
+};


### PR DESCRIPTION
This fixes the randomness of the homepage generator.

The issue was that there was a mismatch of rendering on the server and on the client. Randomness would not be persisted, and so server and client would randomly render different things, resulting in the weirdness of merged tags.

The reason the looping worked is that it was consistent between the server and the client (no randomness).

The solution I propose here is to always generate the randomness on the server, this way it's guaranteed to be consistent.